### PR TITLE
Fix name of graph in test folder generation

### DIFF
--- a/sesame/SesameTestSuite.php
+++ b/sesame/SesameTestSuite.php
@@ -60,7 +60,8 @@ curl -X POST http://dev.grid-observatory.org:8080/openrdf-sesame/repositories/sp
 			} else {
 				$graph = str_replace($this->folder,$this->graph,$value[0]);
 			}
-			$url = $urlGraphData.$graph ;
+
+			$url = $urlGraphData.$this->graph ;
 			 $curl->send_post_content(
 				 $url,
 				 $header,

--- a/sesame/SesameTestSuite.php
+++ b/sesame/SesameTestSuite.php
@@ -26,11 +26,11 @@ curl -X POST http://dev.grid-observatory.org:8080/openrdf-sesame/repositories/sp
 			{
 				if(!mkdir($dirname, 0755, true))
 				{
-					die('Erreur dans la création du répertoire.');
+					die('Erreur dans la crÃ©ation du rÃ©pertoire.');
 				}
 			}
 			$fp = fopen($path, 'w');
-					fwrite($fp,$this->fixTTL(file_get_contents($value[0]),$value[0]));
+					fwrite($fp,$this->fixTTL(file_get_contents($value[0]),$this->graph));
 					fflush($fp);
 					fclose($fp);
 			echo ".";


### PR DESCRIPTION
# Issue

When the sesame test folder is generated, all graph names are a wrong value.

**For example in manifest-all.ttl on line 6**
`<tests/TFT-tests/tests/TFT-tests/sparql11-test-suite\manifest-all.ttl> a mf:Manifest ;`

**for fix this, I change SesameTestSuite.php on line 36 :**
`fwrite($fp,$this->fixTTL(file_get_contents($value[0]),$value[0]));`

by

`fwrite($fp,$this->fixTTL(file_get_contents($value[0])$this->graph));`
